### PR TITLE
docs(readme): add status and tech badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 ![Star Office UI 封面 2](docs/screenshots/readme-cover-2.jpg)
 
+<div align="center">
+
+[![GitHub Stars](https://img.shields.io/github/stars/ringhyacinth/Star-Office-UI?style=flat-square&logo=github)](https://github.com/ringhyacinth/Star-Office-UI/stargazers)
+[![Code License](https://img.shields.io/badge/code-MIT-22c55e?style=flat-square)](LICENSE)
+[![Art Usage](https://img.shields.io/badge/art-non--commercial-important?style=flat-square&color=ea580c)](#5%E7%BE%8E%E6%9C%AF%E8%B5%84%E4%BA%A7%E4%BD%BF%E7%94%A8%E8%AF%B4%E6%98%8E%E8%AF%B7%E5%8B%BF%E5%BF%BD%E8%AF%BB)
+
+[![Tech Stack](https://img.shields.io/badge/backend-Python%20%7C%20Flask-0f766e?style=flat-square&logo=python)](backend)
+[![Frontend](https://img.shields.io/badge/frontend-HTML5%20%7C%20Phaser%203-2563eb?style=flat-square&logo=javascript)](frontend)
+[![Multi‑Agent](https://img.shields.io/badge/agents-OpenClaw--friendly-9333ea?style=flat-square)](docs/STAR_OFFICE_UI_OVERVIEW.md)
+
+</div>
+
 一个面向多 Agent 协作的像素办公室看板：把 AI 助手（OpenClaw / 龙虾）的工作状态实时可视化，帮助团队直观看到“谁在做什么、昨天做了什么、现在是否在线”。
 
 > 本项目为 **Ring Hyacinth 与 Simon Lee 的共同项目（co-created project）**。


### PR DESCRIPTION
Good day,

This pull request makes a small, visual enhancement to the main `README.md` so that the project landing section feels more like a live dashboard and is easier to screenshot or skim at a glance.

The change intentionally stays lightweight and does not touch any runtime code.

#### What this PR changes

Right under the top cover image in `README.md`, a small centered badge block is added:

- **Repository stars**  
  A GitHub stars badge linked to the stargazers page so readers can see how many people have starred the project in real time.

- **Licensing / art usage**  
  - A `code: MIT` badge that points to `LICENSE`.
  - An `art: non‑commercial` badge that links directly to the existing “美术资产使用说明” section, reinforcing the non‑commercial boundary for assets.

- **Tech stack overview**  
  - A backend badge: `backend – Python | Flask` linking to the `backend` directory.
  - A frontend badge: `frontend – HTML5 | Phaser 3` linking to the `frontend` directory.
  - A small `agents – OpenClaw‑friendly` badge that links to the existing overview doc (`docs/STAR_OFFICE_UI_OVERVIEW.md`) to highlight the multi‑agent collaboration angle.

All badges use static shields.io URLs and simple flat‑square styling so they fit the existing aesthetic without being too loud.

#### Rationale

- The main README already has great narrative context and screenshots; these badges add a compact, machine‑readable “status row” without changing any of the story or copy.
- Maintainers can now grab a single screenshot of the top of the README that clearly shows:
  - what the project is about,
  - how many stars it has,
  - what the main technologies are,
  - and what the licensing/asset rules look like.
- The change is documentation‑only, keeping the runtime surface area and stability of the project untouched.

Warmly,
Jah-yee
