### PR TITLE
fix: remove orphaned else block causing SyntaxError in fetchStatus

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4599,13 +4599,6 @@ function toggleBrokerPanel() {
 
                             }
                         }
-                    } else {
-                        if (!typewriterTarget || typewriterTarget !== nextLine) {
-                            typewriterTarget = nextLine;
-                            typewriterText = '';
-                            typewriterIndex = 0;
-                        }
-                        }
                     } catch (err) {
                         console.error('fetchStatus apply error', err);
                         typewriterTarget = '状态更新异常，正在恢复...';


### PR DESCRIPTION
## Problem

In `frontend/index.html`, the `fetchStatus()` function has an orphaned `} else {` block placed between the closing `}` of the `try` block and the `} catch (err) {`. This causes a `SyntaxError: Missing catch or finally after try` at runtime, which prevents the page from loading entirely.

## Root Cause

The `try` block already contains a complete `if (changed) { ... } else { ... }` — the extra `else` block below it is leftover merge artifact that was never cleaned up.

## Fix

Removed the duplicate orphaned `else` block (8 lines) so that `catch` correctly follows `try`.

Fixes #37