### PR TITLE
chore: ignore OpenClaw relay local artifacts (#42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ venv/
 state.json
 agents-state.json
 runtime-config.json
+relay-config.json
+relay-runtime-state.json
 *.log
 *.out
 *.pid


### PR DESCRIPTION
## Summary
- add relay local artifact files to `.gitignore`
  - `relay-config.json`
  - `relay-runtime-state.json`

## Why
Using the OpenClaw relay in local environments leaves machine-local files in repo root, which keeps `git status` noisy and increases accidental staging risk.

## Validation
- `git status --short` no longer reports relay artifacts as untracked after this commit

## Issue
- Closes #42
