### PR TITLE
Fix: 修复 JS 语法错误导致页面无法加载 (#46)

### DIFF
--- a/frontend/electron-standalone.html
+++ b/frontend/electron-standalone.html
@@ -5558,7 +5558,7 @@ function toggleBrokerPanel() {
                             typewriterText = '';
                             typewriterIndex = 0;
                         }
-                        }
+                    }
                     } catch (err) {
                         console.error('fetchStatus apply error', err);
                         typewriterTarget = '状态更新异常，正在恢复...';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1170,7 +1170,7 @@
             <div id="asset-auth-gate" class="asset-preview-box">
                 <div class="asset-preview-title">请输入装修验证码</div>
                 <div class="asset-toolbar">
-                    <input id="asset-pass-input" type="password" placeholder="输入验证码" />
+                    <input id="asset-pass-input" type="password" placeholder="输入验证码" onkeydown="if(event.key==='Enter')unlockAssetDrawer()" />
                     <button onclick="unlockAssetDrawer()">验证</button>
                 </div>
                 <div id="asset-auth-msg" class="asset-sub"></div>
@@ -3875,12 +3875,26 @@ function toggleBrokerPanel() {
             loadedAssets = 0;
             
             // 加载进度监听
+            let loadFailed = false;
             this.load.on('filecomplete', () => {
                 updateLoadingProgress();
             });
-            
+            this.load.on('loaderror', (fileObj) => {
+                loadFailed = true;
+                console.warn('资源加载失败:', fileObj.key, fileObj.src);
+            });
+
             this.load.on('complete', () => {
-                hideLoadingOverlay();
+                if (loadFailed) {
+                    const isFileProtocol = location.protocol === 'file:';
+                    const hint = isFileProtocol
+                        ? '请通过后端服务访问：先运行 python3 backend/app.py，然后打开 http://127.0.0.1:18791'
+                        : '部分资源加载失败，请检查后端服务是否正常运行';
+                    if (loadingText) loadingText.textContent = hint;
+                    if (loadingProgressContainer) loadingProgressContainer.style.display = 'none';
+                } else {
+                    hideLoadingOverlay();
+                }
             });
 
             // cache-busting to avoid stale background on client/CDN
@@ -4598,13 +4612,6 @@ function toggleBrokerPanel() {
                                 typewriterIndex = 0;
 
                             }
-                        }
-                    } else {
-                        if (!typewriterTarget || typewriterTarget !== nextLine) {
-                            typewriterTarget = nextLine;
-                            typewriterText = '';
-                            typewriterIndex = 0;
-                        }
                         }
                     } catch (err) {
                         console.error('fetchStatus apply error', err);


### PR DESCRIPTION
## Summary
- **修复 `fetchStatus()` 中重复的 `} else { ... }` 块导致的 JS 语法错误** — 这是页面永远卡在 loading 的根本原因
- 为资产验证码输入框添加回车键提交支持
- 资源加载失败时显示友好提示（如直接用 `file://` 打开 HTML 时引导用户启动后端）

Closes #46

## Test plan
- [ ] 启动后端 `python3 backend/app.py`，访问 `http://127.0.0.1:18791`，页面正常加载不再卡在 loading
- [ ] 打开"装修房间"侧边栏，输入密码后按回车可正常提交
- [ ] 直接用浏览器打开 `frontend/index.html`，loading 界面显示提示信息而非永远转圈
- [ ] Electron standalone 版本同样正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)