### PR TITLE
fix: Remove invalid try-else syntax in fetchStatus

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4599,13 +4599,6 @@ function toggleBrokerPanel() {
 
                             }
                         }
-                    } else {
-                        if (!typewriterTarget || typewriterTarget !== nextLine) {
-                            typewriterTarget = nextLine;
-                            typewriterText = '';
-                            typewriterIndex = 0;
-                        }
-                        }
                     } catch (err) {
                         console.error('fetchStatus apply error', err);
                         typewriterTarget = '状态更新异常，正在恢复...';


### PR DESCRIPTION
## Description

Removes invalid JavaScript syntax (try { } else { }) in the fetchStatus() function.

The try-catch block had an invalid 'else' block after it which is not valid JavaScript syntax. This caused the JavaScript to fail parsing in some browsers/environments with error: 'Missing catch or finally after try'

## Changes

- Removed 7 lines of invalid 'else' block code after the try-catch in fetchStatus()

## Testing

- Verified JavaScript syntax is now valid using acorn parser
- Tested in Playwright Chrome - game now loads correctly

## Fixes

Fixes #50