### PR TITLE
fix: remove stray else block in fetchStatus() causing JS syntax error

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4596,15 +4596,7 @@ function toggleBrokerPanel() {
                                 typewriterTarget = nextLine;
                                 typewriterText = '';
                                 typewriterIndex = 0;
-
                             }
-                        }
-                    } else {
-                        if (!typewriterTarget || typewriterTarget !== nextLine) {
-                            typewriterTarget = nextLine;
-                            typewriterText = '';
-                            typewriterIndex = 0;
-                        }
                         }
                     } catch (err) {
                         console.error('fetchStatus apply error', err);


### PR DESCRIPTION
## Problem

The `fetchStatus()` function in `frontend/index.html` (line ~4599) contains a dangling `} else {` block after the `try` body that does not pair with any `if` statement:

```js
                        }
                    } else {           // ← orphaned else, no matching if
                        if (!typewriterTarget || typewriterTarget !== nextLine) {
                            typewriterTarget = nextLine;
                            typewriterText = '';
                            typewriterIndex = 0;
                        }
                        }
                    } catch (err) {
```

This causes a JavaScript parse error:
> `SyntaxError: Missing catch or finally after try`

Since all game logic is in a single inline `<script>` block, **this prevents the entire script from executing** — Phaser never initializes and the page is permanently stuck on the loading overlay.

## Fix

Removed the orphaned `} else {` block (8 lines). The duplicate typewriter-update logic it contained was already handled by the preceding `if/else` branch inside the `try` body.

## Verification

- Validated the fix with Node.js `new Function()` parse check — no syntax errors after the fix.
- Tested end-to-end: Phaser initializes, assets load, loading overlay hides, office renders correctly with all animations.