### PR TITLE
chore: quarantine hardening controls + authz options (OPS-020)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv/
 state.json
 agents-state.json
 runtime-config.json
+join-keys.json
 *.log
 *.out
 *.pid
@@ -36,3 +37,10 @@ desktop-pet/src-tauri/icons/*Logo.png
 # Electron local build artifacts
 electron-shell/node_modules/
 electron-shell/release/
+
+# Pilot runtime artifacts
+pilot/*.env
+pilot/*.pid
+pilot/*.log
+pilot/*.flag
+pilot/metrics-latest.json

--- a/backend/app.py
+++ b/backend/app.py
@@ -1951,6 +1951,7 @@ def assets_upload():
 
 if __name__ == "__main__":
     raw_port = os.environ.get("STAR_BACKEND_PORT", "18791")
+    backend_host = os.environ.get("STAR_BACKEND_HOST", "0.0.0.0").strip() or "0.0.0.0"
     try:
         backend_port = int(raw_port)
     except ValueError:
@@ -1962,7 +1963,7 @@ if __name__ == "__main__":
     print("Star Office UI - Backend State Service")
     print("=" * 50)
     print(f"State file: {STATE_FILE}")
-    print(f"Listening on: http://0.0.0.0:{backend_port}")
+    print(f"Listening on: http://{backend_host}:{backend_port}")
     mode = "production" if is_production_mode() else "development"
     print(f"Mode: {mode}")
     if is_production_mode():
@@ -1979,5 +1980,5 @@ if __name__ == "__main__":
             print("Security hardening: OK")
     print("=" * 50)
 
-    app.run(host="0.0.0.0", port=backend_port, debug=False)
+    app.run(host=backend_host, port=backend_port, debug=False)
 

--- a/pilot/AUTHZ_IMPLEMENTATION_OPTIONS.md
+++ b/pilot/AUTHZ_IMPLEMENTATION_OPTIONS.md
@@ -1,0 +1,63 @@
+# AuthZ Implementation Options — OPS-020 Quarantine Pilot
+
+## Context
+Current pilot keeps network exposure constrained (loopback bind + feature flag), but write endpoints (e.g. `/set_state`) should be explicitly authorized before any broader internal exposure.
+
+## Option A — In-App RBAC (service-level authz)
+
+### Design
+- Add API key/JWT middleware in Flask app.
+- Define roles/scopes:
+  - `viewer`: read-only endpoints (`/health`, `/status`, `/agents`)
+  - `operator`: state mutation (`/set_state`, `/agent-push`)
+  - `admin`: asset/config mutation endpoints
+- Enforce scope checks per route.
+- Emit audit logs per denied/allowed write request.
+
+### Pros
+- Defense in depth even if gateway policy misconfigured.
+- Fine-grained control at route level.
+- Portable across environments.
+
+### Cons
+- Higher implementation/maintenance complexity.
+- Secret/key lifecycle must be managed in app.
+- Requires test matrix expansion.
+
+### Effort
+- Medium (1–2 days to implement + test + docs for pilot scope).
+
+## Option B — Strict Gateway-Only Policy (external authz)
+
+### Design
+- Keep Flask service private (loopback/internal network only).
+- Route all access through trusted gateway/reverse proxy.
+- Gateway enforces:
+  - authentication
+  - allowlisted principals
+  - method/path policy (deny public write paths)
+  - optional mTLS/internal-token headers for write routes
+- App remains mostly unchanged; no in-app RBAC complexity.
+
+### Pros
+- Fastest path for 48h sprint.
+- Centralized policy and credential handling.
+- Minimal app changes, lower near-term regression risk.
+
+### Cons
+- Relies on gateway correctness.
+- Less portable if moved outside managed gateway perimeter.
+- Weaker defense-in-depth than dual-layer model.
+
+### Effort
+- Small (hours, assuming gateway policy pipeline is available).
+
+## Recommendation (Pilot horizon)
+- **Pilot (48h): Option B strict gateway-only policy** to hit speed + safety constraints.
+- **Post-pilot hardening:** add Option A in-app RBAC for defense-in-depth before broader rollout.
+
+## Minimum acceptance criteria for either option
+- No unauthenticated write path exposed externally.
+- Audit trail exists for every write success/failure.
+- Negative tests prove unauthorized write requests are rejected.
+- Rollback path documented and tested.

--- a/pilot/OPS-020-gate-evidence-2026-03-05-0921.md
+++ b/pilot/OPS-020-gate-evidence-2026-03-05-0921.md
@@ -1,0 +1,91 @@
+# OPS-020 Gate Evidence Snapshot — 2026-03-05 09:21 ET
+
+Scope: Star-Office-UI quarantine pilot (internal/staging only)
+Status policy: PASS / FAIL / UNVERIFIED
+
+## Legal
+
+- L1: **PASS**
+  - Evidence: `LICENSE` contains MIT grant for code logic.
+  - Ref: `LICENSE:1-28`
+
+- L2: **FAIL** (commercial gate not closed)
+  - Evidence: art assets explicitly non-commercial.
+  - Refs:
+    - `LICENSE:33-45`
+    - `README.en.md:173,181`
+    - `README.md:173,287`
+
+- L3: **UNVERIFIED**
+  - Evidence missing: legal/commercial sign-off artifact or proof all art assets replaced.
+
+## Dependency
+
+- D1: **FAIL**
+  - Evidence: runtime parity incomplete (Pillow absent in pilot runtime).
+  - Command output:
+    - `python3 --version` => `Python 3.14.3`
+    - `.venv-pilot/bin/python -c ...` => `pillow NOT_INSTALLED`
+
+- D2: **PASS** (limited scope)
+  - Evidence: active pilot environment dependency integrity check.
+  - Command output:
+    - `.venv-pilot/bin/pip check` => `No broken requirements found.`
+
+- D3: **FAIL**
+  - Evidence: dependency control mismatch/no full lock parity for Python lane.
+  - Command output:
+    - `ls backend/requirements.txt pyproject.toml package-lock.json` => only `backend/requirements.txt`, `pyproject.toml` present
+
+## Supply-chain
+
+- S1: **PASS**
+  - Evidence: source revision pinned for current assessment.
+  - Command output:
+    - `git rev-parse --short HEAD` => `53d33d6`
+    - `git rev-parse --abbrev-ref HEAD` => `master`
+
+- S2: **UNVERIFIED**
+  - Evidence missing: commit/tag signature verification artifact.
+
+- S3: **UNVERIFIED**
+  - Evidence missing: dependency provenance attestations / signed provenance chain.
+
+- S4: **UNVERIFIED**
+  - Evidence missing: SBOM + checksum artifact for release candidate.
+
+## Hardening
+
+- H1: **PASS**
+  - Evidence: app preflight hardening check in production mode env.
+  - Command output:
+    - `.venv-pilot/bin/python scripts/security_check.py` => `Result: OK`
+
+- H2: **PASS**
+  - Evidence: quarantine isolation active and bound loopback-only.
+  - Command output:
+    - `./pilot/quarantine-control.sh status` => `service=RUNNING ... port=18991`
+    - `ss -ltn | rg ':18991'` => `LISTEN ... 127.0.0.1:18991`
+
+- H3: **PASS**
+  - Evidence: feature flag + rollback switch armed.
+  - Command output:
+    - `./pilot/quarantine-control.sh status` => `feature_flag=ON`, `rollback_switch=ENABLED`
+  - Rollback command:
+    - `./pilot/quarantine-control.sh rollback`
+
+- H4: **FAIL**
+  - Evidence: unauthenticated write endpoint present in app code.
+  - Ref:
+    - `backend/app.py:1238` route `/set_state` (no auth guard before state write)
+
+- H5: **UNVERIFIED**
+  - Evidence pending: Sentinel gate acknowledgment artifact.
+  - Related platform signal:
+    - `openclaw security audit --deep` => `0 critical · 1 warn · 1 info`
+    - warning: multi-user heuristic / sandbox posture not fully hardened.
+
+## Current gate decision
+
+- **Production/commercial: NO-GO**
+- **Quarantine internal pilot: GO (restricted scope only)**

--- a/pilot/PR_ARTIFACT_INDEX.md
+++ b/pilot/PR_ARTIFACT_INDEX.md
@@ -1,0 +1,29 @@
+# PR Artifact Index — Quarantine / Hardening Track
+
+## In-repo artifacts
+- Quarantine gate evidence:
+  - `pilot/OPS-020-gate-evidence-2026-03-05-0921.md`
+- AuthZ implementation options:
+  - `pilot/AUTHZ_IMPLEMENTATION_OPTIONS.md`
+- Quarantine metrics snapshot:
+  - `pilot/metrics-baseline-2026-03-05.json`
+  - `pilot/metrics-latest.json` (runtime-generated)
+
+## Cross-workspace artifact (Obsidian)
+- C1-BUILD checkpoint (required path):
+  - `/home/tekron/.openclaw/workspace-obsidian/artifacts/ops-020/gallium-build-checkpoint.md`
+
+## Verification commands
+```bash
+# Quarantine status
+./pilot/quarantine-control.sh status
+
+# Security preflight
+set -a && source pilot/quarantine.env && set +a && .venv-pilot/bin/python scripts/security_check.py
+
+# Probe metrics
+python3 pilot/collect_metrics.py
+
+# Smoke
+python3 scripts/smoke_test.py --base-url http://127.0.0.1:18991
+```

--- a/pilot/collect_metrics.py
+++ b/pilot/collect_metrics.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json, os, time, statistics, urllib.request, urllib.error
+
+PORT = int(os.getenv("STAR_BACKEND_PORT", "18991"))
+BASE = f"http://127.0.0.1:{PORT}"
+FLAG = os.path.join(os.path.dirname(__file__), "STAR_OFFICE_PILOT.flag")
+
+def req(method: str, path: str, body: dict | None = None):
+    data = None
+    headers = {}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    r = urllib.request.Request(BASE + path, method=method, data=data, headers=headers)
+    t0 = time.perf_counter()
+    code = 0
+    err = ""
+    size = 0
+    try:
+        with urllib.request.urlopen(r, timeout=5) as resp:
+            raw = resp.read()
+            size = len(raw)
+            code = resp.status
+    except urllib.error.HTTPError as e:
+        code = e.code
+        err = str(e)
+    except Exception as e:
+        err = str(e)
+    ms = (time.perf_counter() - t0) * 1000
+    return {"code": code, "ms": ms, "err": err, "bytes": size}
+
+def ttfv_probe():
+    url = BASE + "/"
+    t0 = time.perf_counter()
+    t_first = None
+    total_bytes = 0
+    code = 0
+    err = ""
+    try:
+        with urllib.request.urlopen(url, timeout=8) as resp:
+            code = resp.status
+            first = resp.read(1)
+            t_first = (time.perf_counter() - t0) * 1000
+            total_bytes += len(first)
+            rest = resp.read()
+            total_bytes += len(rest)
+    except Exception as e:
+        err = str(e)
+    full_ms = (time.perf_counter() - t0) * 1000
+    return {
+        "code": code,
+        "ttfb_ms": round(t_first or 0, 2),
+        "ttfv_proxy_ms": round(t_first or 0, 2),
+        "full_load_ms": round(full_ms, 2),
+        "bytes": total_bytes,
+        "err": err,
+    }
+
+def summarize(samples):
+    lat = [s["ms"] for s in samples]
+    codes = [s["code"] for s in samples]
+    errs = sum(1 for c in codes if c >= 400 or c == 0)
+    return {
+        "count": len(samples),
+        "ok": sum(1 for c in codes if 200 <= c < 400),
+        "errors": errs,
+        "error_rate": round((errs / len(samples))*100, 2) if samples else 0,
+        "avg_ms": round(statistics.mean(lat), 2) if lat else 0,
+        "p95_ms": round(sorted(lat)[max(0, int(len(lat)*0.95)-1)], 2) if lat else 0,
+    }
+
+def run_endpoint(method, path, n, body=None):
+    return [req(method, path, body=body) for _ in range(n)]
+
+out = {
+    "base_url": BASE,
+    "feature_flag": "ON" if os.path.exists(FLAG) else "OFF",
+    "rollback_switch_state": "ARMED" if os.path.exists(FLAG) else "DISARMED",
+    "ttfv": ttfv_probe(),
+}
+health = run_endpoint("GET", "/health", 20)
+status = run_endpoint("GET", "/status", 20)
+agents = run_endpoint("GET", "/agents", 20)
+set_state = run_endpoint("POST", "/set_state", 10, body={"state":"idle","detail":"pilot-probe"})
+out["health_probe_stats"] = summarize(health)
+out["status_probe_stats"] = summarize(status)
+out["agents_probe_stats"] = summarize(agents)
+out["set_state_probe_stats"] = summarize(set_state)
+out["endpoint_error_stats"] = {
+    "total_calls": 70,
+    "total_errors": out["health_probe_stats"]["errors"] + out["status_probe_stats"]["errors"] + out["agents_probe_stats"]["errors"] + out["set_state_probe_stats"]["errors"],
+}
+out["endpoint_error_stats"]["error_rate"] = round(out["endpoint_error_stats"]["total_errors"] / out["endpoint_error_stats"]["total_calls"] * 100, 2)
+print(json.dumps(out, ensure_ascii=False, indent=2))

--- a/pilot/gallium-build-checkpoint-copy.md
+++ b/pilot/gallium-build-checkpoint-copy.md
@@ -1,0 +1,51 @@
+# OPS-020 — Gallium C1-BUILD Checkpoint
+
+- Owner: Gallium
+- Checkpoint: C1-BUILD (Quarantine Pilot)
+- Timestamp: 2026-03-05 09:39 ET
+- Scope: Star-Office-UI quarantine pilot (internal-only)
+
+## 1) Quarantine build plan
+
+- Isolation model:
+  - Run Star-Office-UI in quarantine runtime with feature flag gate.
+  - Bind service to loopback only (`127.0.0.1:18991`) to prevent external exposure.
+  - Separate control harness (`pilot/quarantine-control.sh`) for enable/start/status/rollback.
+- Hardening controls:
+  - Production-mode env checks enabled (`STAR_OFFICE_ENV=production`).
+  - Strong secret + drawer pass in quarantine env.
+  - Security preflight command executed: `scripts/security_check.py` => OK.
+- Runtime posture:
+  - No production cutover.
+  - Internal/staging route only.
+  - Rollback always armed.
+
+## 2) Integration sequence
+
+1. Initialize quarantine env + runtime files from samples.
+2. Enable feature flag (`pilot/STAR_OFFICE_PILOT.flag`).
+3. Start service in quarantine mode (loopback bind).
+4. Verify health endpoints (`/health`, `/status`, `/agents`, `/set_state`).
+5. Capture baseline metrics (TTFV, health probes, endpoint error rate).
+6. Run smoke test (`scripts/smoke_test.py --base-url http://127.0.0.1:18991`).
+7. Hold in internal-only pilot state pending security gate closure for broader exposure.
+
+## 3) Rollback triggers
+
+- Trigger immediate rollback if any of the following occur:
+  - Endpoint error rate > 2% over probe window.
+  - Health probe failures >= 2 consecutive checks.
+  - Unexpected external bind (anything other than `127.0.0.1:18991`).
+  - Security preflight failure or Sentinel gate regression.
+  - Functional regressions impacting primary dashboard operations.
+- Rollback command:
+  - `./pilot/quarantine-control.sh rollback`
+  - Effect: stop service + disable feature flag.
+
+## 4) Recommendation
+
+- Recommendation: **CONDITIONAL**
+- Rationale:
+  - Build/instrumentation and quarantine controls are operational (internal pilot viable).
+  - Broader exposure remains blocked until unresolved security/legal/dependency gates close.
+  - Production/commercial remains NO-GO under current gate state.

--- a/pilot/metrics-baseline-2026-03-05.json
+++ b/pilot/metrics-baseline-2026-03-05.json
@@ -1,0 +1,50 @@
+{
+  "base_url": "http://127.0.0.1:18991",
+  "feature_flag": "ON",
+  "rollback_switch_state": "ARMED",
+  "ttfv": {
+    "code": 200,
+    "ttfb_ms": 6.8,
+    "ttfv_proxy_ms": 6.8,
+    "full_load_ms": 6.9,
+    "bytes": 243354,
+    "err": ""
+  },
+  "health_probe_stats": {
+    "count": 20,
+    "ok": 20,
+    "errors": 0,
+    "error_rate": 0.0,
+    "avg_ms": 0.66,
+    "p95_ms": 0.79
+  },
+  "status_probe_stats": {
+    "count": 20,
+    "ok": 20,
+    "errors": 0,
+    "error_rate": 0.0,
+    "avg_ms": 0.62,
+    "p95_ms": 0.77
+  },
+  "agents_probe_stats": {
+    "count": 20,
+    "ok": 20,
+    "errors": 0,
+    "error_rate": 0.0,
+    "avg_ms": 0.72,
+    "p95_ms": 0.97
+  },
+  "set_state_probe_stats": {
+    "count": 10,
+    "ok": 10,
+    "errors": 0,
+    "error_rate": 0.0,
+    "avg_ms": 0.72,
+    "p95_ms": 0.78
+  },
+  "endpoint_error_stats": {
+    "total_calls": 70,
+    "total_errors": 0,
+    "error_rate": 0.0
+  }
+}

--- a/pilot/quarantine-control.sh
+++ b/pilot/quarantine-control.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT/pilot/quarantine.env"
+FLAG_FILE="$ROOT/pilot/STAR_OFFICE_PILOT.flag"
+PID_FILE="$ROOT/pilot/star-office-quarantine.pid"
+LOG_FILE="$ROOT/pilot/star-office-quarantine.log"
+
+load_env() {
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "env missing: $ENV_FILE" >&2
+    exit 1
+  fi
+  set -a
+  source "$ENV_FILE"
+  set +a
+}
+
+is_running() {
+  [[ -f "$PID_FILE" ]] || return 1
+  local pid
+  pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+cmd_enable() {
+  touch "$FLAG_FILE"
+  echo "FLAG=ON"
+}
+
+cmd_disable() {
+  rm -f "$FLAG_FILE"
+  echo "FLAG=OFF"
+}
+
+cmd_start() {
+  [[ -f "$FLAG_FILE" ]] || { echo "Refusing start: feature flag OFF"; exit 2; }
+  if is_running; then
+    echo "already running (pid $(cat "$PID_FILE"))"
+    exit 0
+  fi
+  load_env
+  nohup "$ROOT/.venv-pilot/bin/python" "$ROOT/backend/app.py" >"$LOG_FILE" 2>&1 &
+  echo $! > "$PID_FILE"
+  sleep 1
+  if is_running; then
+    echo "started pid=$(cat "$PID_FILE") port=${STAR_BACKEND_PORT:-18991}"
+  else
+    echo "failed to start; check $LOG_FILE" >&2
+    exit 1
+  fi
+}
+
+cmd_stop() {
+  if is_running; then
+    kill "$(cat "$PID_FILE")" || true
+    sleep 1
+    if is_running; then
+      kill -9 "$(cat "$PID_FILE")" || true
+    fi
+  fi
+  rm -f "$PID_FILE"
+  echo "stopped"
+}
+
+cmd_status() {
+  load_env
+  echo "feature_flag=$([[ -f "$FLAG_FILE" ]] && echo ON || echo OFF)"
+  echo "rollback_switch=$([[ -f "$FLAG_FILE" ]] && echo ENABLED || echo READY_OFF)"
+  if is_running; then
+    echo "service=RUNNING pid=$(cat "$PID_FILE") port=${STAR_BACKEND_PORT:-18991}"
+    curl -s -o /dev/null -w "health_http=%{http_code}\n" "http://127.0.0.1:${STAR_BACKEND_PORT:-18991}/health" || true
+  else
+    echo "service=STOPPED"
+  fi
+}
+
+cmd_rollback() {
+  cmd_stop
+  cmd_disable
+  echo "ROLLBACK=COMPLETE"
+}
+
+case "${1:-}" in
+  enable) cmd_enable ;;
+  disable) cmd_disable ;;
+  start) cmd_start ;;
+  stop) cmd_stop ;;
+  status) cmd_status ;;
+  rollback) cmd_rollback ;;
+  *) echo "usage: $0 {enable|disable|start|stop|status|rollback}"; exit 1 ;;
+esac

--- a/pilot/quarantine.env.example
+++ b/pilot/quarantine.env.example
@@ -1,0 +1,8 @@
+STAR_OFFICE_ENV=production
+FLASK_ENV=production
+FLASK_SECRET_KEY=replace-with-strong-secret-min-24-chars
+ASSET_DRAWER_PASS=replace-with-strong-pass-min-8-chars
+STAR_BACKEND_PORT=18991
+STAR_BACKEND_HOST=127.0.0.1
+AUTO_ROTATE_HOME_ON_PAGE_OPEN=0
+PILOT_MODE=quarantine


### PR DESCRIPTION
## Summary
This PR packages the quarantine hardening track artifacts and controls for OPS-020 pilot readiness (internal-only).

### Included
- Quarantine runtime control harness: `pilot/quarantine-control.sh`
- Metrics probe utility: `pilot/collect_metrics.py`
- Loopback-host support for backend bind via `STAR_BACKEND_HOST` (`backend/app.py`)
- AuthZ decision brief: `pilot/AUTHZ_IMPLEMENTATION_OPTIONS.md`
- Gate evidence + checkpoint artifacts
- Runtime hygiene updates in `.gitignore` and `pilot/quarantine.env.example`

## Artifact links
- Gate evidence: `pilot/OPS-020-gate-evidence-2026-03-05-0921.md`
- C1-BUILD checkpoint copy: `pilot/gallium-build-checkpoint-copy.md`
- AuthZ options: `pilot/AUTHZ_IMPLEMENTATION_OPTIONS.md`
- Artifact index + verify commands: `pilot/PR_ARTIFACT_INDEX.md`
- Metrics baseline: `pilot/metrics-baseline-2026-03-05.json`

## Verification commands
```bash
./pilot/quarantine-control.sh status
set -a && source pilot/quarantine.env && set +a && .venv-pilot/bin/python scripts/security_check.py
python3 pilot/collect_metrics.py
python3 scripts/smoke_test.py --base-url http://127.0.0.1:18991
```

## Scope boundary
- No production cutover
- Internal/staging quarantine only
- Rollback remains one-command: `./pilot/quarantine-control.sh rollback`
