### PR TITLE
docs(join-keys): align docs with runtime sample file

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -137,7 +137,7 @@ Add the following rule to your `SOUL.md` (or agent config) so your lobster updat
 
 **Step 1: Prepare join keys**
 
-The repo ships with `join-keys.json` (containing `ocj_starteam01` through `ocj_starteam08`), each supporting up to 3 concurrent users. Feel free to add your own keys.
+When you start the backend for the first time, if there is no `join-keys.json` in the project root, the service will automatically create one based on `join-keys.sample.json` (which contains an example key such as `ocj_example_team_01`). You can then edit the generated `join-keys.json` to add, modify, or remove keys; by default each key supports up to 3 concurrent users.
 
 **Step 2: Have the guest run the push script**
 
@@ -256,7 +256,7 @@ Star-Office-UI/
 ├── office-agent-push.py  # Guest push script
 ├── set_state.py          # Status switch script
 ├── state.sample.json     # State file template
-├── join-keys.json        # Join key config
+├── join-keys.sample.json # Join key template (runtime generates join-keys.json)
 ├── SKILL.md              # OpenClaw Skill
 └── LICENSE               # MIT License
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -137,7 +137,7 @@ cp SKILL.md ~/.openclaw/workspace/SKILL.md
 
 **Step 1：join key を準備**
 
-リポジトリには `join-keys.json`（`ocj_starteam01` 〜 `ocj_starteam08`）が含まれており、各キーで最大 3 名まで同時接続可能。独自のキーを追加することもできます。
+バックエンドを初回起動するとき、カレントディレクトリに `join-keys.json` が存在しない場合は、`join-keys.sample.json` を元にランタイム用の `join-keys.json` が自動生成されます（例として `ocj_example_team_01` などのサンプル key が含まれます）。生成された `join-keys.json` を編集して key を追加・変更・削除できます。各 key はデフォルトで最大 3 名まで同時接続できます。
 
 **Step 2：ゲストにプッシュスクリプトを実行してもらう**
 
@@ -256,7 +256,7 @@ Star-Office-UI/
 ├── office-agent-push.py  # ゲストプッシュスクリプト
 ├── set_state.py          # ステータス切替スクリプト
 ├── state.sample.json     # 状態ファイルテンプレート
-├── join-keys.json        # Join Key 設定
+├── join-keys.sample.json # Join Key テンプレート（起動時に join-keys.json を生成）
 ├── SKILL.md              # OpenClaw Skill
 └── LICENSE               # MIT ライセンス
 ```

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ cp SKILL.md ~/.openclaw/workspace/SKILL.md
 
 **Step 1：准备 join key**
 
-仓库默认提供 `join-keys.json`（含 `ocj_starteam01` ~ `ocj_starteam08`），每个 key 最多 3 人同时在线。你也可以自行编辑添加新 key。
+首次启动后端时，如果当前目录下不存在 `join-keys.json`，服务会自动根据 `join-keys.sample.json` 生成一个运行时的 `join-keys.json`（内含示例 key，例如 `ocj_example_team_01`）。你可以在生成后的 `join-keys.json` 中自行添加、修改或删除 key，每个 key 默认支持最多 3 人同时在线。
 
 **Step 2：让访客龙虾运行推送脚本**
 
@@ -256,7 +256,7 @@ Star-Office-UI/
 ├── office-agent-push.py  # 访客推送脚本
 ├── set_state.py          # 状态切换脚本
 ├── state.sample.json     # 状态文件模板
-├── join-keys.json        # Join Key 配置
+├── join-keys.sample.json # Join Key 模板（启动时生成 join-keys.json）
 ├── SKILL.md              # OpenClaw Skill
 └── LICENSE               # MIT 许可
 ```


### PR DESCRIPTION
Good day,

This pull request makes a small documentation-only adjustment so that the README descriptions of join keys match the current runtime behavior and repository layout.

#### Background

Recent updates moved `join-keys.json` out of version control and introduced `join-keys.sample.json` as a template. At runtime, the backend now:

- Treats `join-keys.json` as a runtime file (not committed).
- Uses `join-keys.sample.json` as the seed template when `join-keys.json` does not exist.

However, the three README variants (`README.md`, `README.en.md`, `README.ja.md`) still state that the repo “ships with `join-keys.json` containing `ocj_starteam01` ~ `ocj_starteam08`”, and the project structure diagrams still list `join-keys.json` directly. This can be confusing for people who clone the repo and don’t see that file.

#### What this PR changes

In all three READMEs (Chinese / English / Japanese):

1. **Step 4.3 – join key preparation**  
   - Update the text to explain that:
     - On first backend startup, if `join-keys.json` is missing in the project root, the service **automatically generates** it from `join-keys.sample.json`.
     - The sample file contains an example key (e.g. `ocj_example_team_01`).
     - Users are expected to edit the generated `join-keys.json` to add/modify/remove keys, and that each key supports up to 3 concurrent users by default.

2. **Project structure section**  
   - Replace the direct `join-keys.json` entry with `join-keys.sample.json`, annotated as a template:
     - CN: “Join Key 模板（启动时生成 join-keys.json）”
     - EN: “Join key template (runtime generates join-keys.json)”
     - JA: “Join Key テンプレート（起動時に join-keys.json を生成）”

No behavior, configuration, or code paths are changed in this PR; it only adjusts prose to reflect how the backend already works.

#### Rationale

- New users get documentation that matches what they actually see on disk after cloning the repo.
- It becomes clearer that `join-keys.json` is a runtime artifact and should be customized per deployment, while `join-keys.sample.json` is the shared template.
- The change is intentionally minimal and localized to documentation to avoid impacting stability.

Warmly,
Jah-yee
