### PR TITLE
docs(readme): add env and smoke test hints

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -79,6 +79,8 @@ python3 app.py
 
 Open `http://127.0.0.1:18791`
 
+> ✅ For local development you can start with the defaults; in production, copy `.env.example` to `.env` and set strong random values for `FLASK_SECRET_KEY` and `ASSET_DRAWER_PASS` to avoid weak passwords and session leaks.
+
 ### 4) Switch states
 
 ```bash
@@ -95,6 +97,16 @@ cloudflared tunnel --url http://127.0.0.1:18791
 ```
 
 Share the `https://xxx.trycloudflare.com` link with anyone.
+
+### 6) Verify your installation (optional)
+
+While the backend is running, you can run a lightweight smoke test to confirm that the core endpoints are healthy:
+
+```bash
+python3 scripts/smoke_test.py --base-url http://127.0.0.1:18791
+```
+
+If all checks report `OK`, your Star Office UI service is wired up correctly for basic status flows.
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -30,6 +30,8 @@ python3 app.py
 
 **http://127.0.0.1:18791** を開き、状態を切り替えてみましょう：
 
+> ✅ ローカル開発ではデフォルト設定のままで構いませんが、本番環境では `.env.example` を `.env` にコピーし、`FLASK_SECRET_KEY` と `ASSET_DRAWER_PASS` に十分な長さのランダム値を設定することをおすすめします（弱いパスワードやセッション漏洩を防ぐため）。
+
 ```bash
 python3 set_state.py writing "ドキュメント整理中"
 python3 set_state.py error "問題を検出、調査中"
@@ -39,6 +41,16 @@ python3 set_state.py idle "待機中"
 ![Star Office UI プレビュー](docs/screenshots/readme-cover-1.jpg)
 
 ---
+
+## ✅ インストール確認（任意）
+
+バックエンドが起動している状態で、簡単な smoke test を実行して主要エンドポイントが正常かどうかを確認できます：
+
+```bash
+python3 scripts/smoke_test.py --base-url http://127.0.0.1:18791
+```
+
+すべてのチェックが `OK` と表示されれば、Star Office UI の基本的なステータスフローが正しく動作していることを意味します。
 
 ## 📋 機能一覧
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ python3 app.py
 
 打开 `http://127.0.0.1:18791`
 
+> ✅ 如果你是首次部署，可以先保留默认的开发配置；在生产环境中，请复制 `.env.example` 为 `.env` 并设置强随机的 `FLASK_SECRET_KEY` 与 `ASSET_DRAWER_PASS`，避免弱密码和会话泄露。
+
 ### 4) 切换状态
 
 ```bash
@@ -95,6 +97,16 @@ cloudflared tunnel --url http://127.0.0.1:18791
 ```
 
 拿到 `https://xxx.trycloudflare.com` 链接即可分享。
+
+### 6) 验证安装（可选）
+
+在后端运行中时，可以执行一次轻量级的 smoke test，确认核心接口是否正常工作：
+
+```bash
+python3 scripts/smoke_test.py --base-url http://127.0.0.1:18791
+```
+
+如果所有检查都显示 `OK`，说明后端路由和基础状态流转已经就绪。
 
 ---
 


### PR DESCRIPTION
Good day,

This pull request adds a small “onboarding” layer to the three READMEs so that new users have clearer guidance for production environment variables and a simple way to verify their installation without touching the runtime code.

#### What this PR changes

In `README.md`, `README.en.md`, and `README.ja.md`:

1. **Production `.env` hint near backend startup**  
   Right after the step where the backend is started and `http://127.0.0.1:18791` is opened, a short note is added in each language:

   - For local development: the defaults are fine.
   - For production deployments: copy `.env.example` to `.env` and set strong random values for:
     - `FLASK_SECRET_KEY`
     - `ASSET_DRAWER_PASS`

   The note explicitly mentions the reason (avoiding weak passwords and session leaks) but keeps the wording lightweight, so it doesn’t overwhelm first-time readers.

2. **Optional “Verify your installation” / smoke test section**  
   A small optional section is added after the “public access” step:

   - Suggests running the non-destructive smoke test script while the backend is running:

     ```bash
     python3 scripts/smoke_test.py --base-url http://127.0.0.1:18791
     ```

   - Explains that if all checks report `OK`, the core endpoints and basic status flows are wired up correctly.
   - The section is localized in Chinese / English / Japanese but the command remains the same for consistency.

#### Rationale

- The repository already ships with `.env.example` and `scripts/smoke_test.py`; this PR simply surfaces them in the main documentation so they are discoverable.
- New users get a gentle pointer about production-hardening without being forced to read deeper docs first.
- The smoke test gives maintainers and operators a one-command sanity check for CI, staging, or after upgrading.
- No application logic, routes, or config handling are changed; this PR is documentation-only and keeps the runtime surface stable.

Warmly,
Jah-yee
