### PR TITLE
feat(health): add service field for monitoring

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1211,7 +1211,11 @@ def agent_push():
 @app.route("/health", methods=["GET"])
 def health():
     """Health check"""
-    return jsonify({"status": "ok", "timestamp": datetime.now().isoformat()})
+    return jsonify({
+        "status": "ok",
+        "service": "star-office-ui",
+        "timestamp": datetime.now().isoformat(),
+    })
 
 
 @app.route("/yesterday-memo", methods=["GET"])


### PR DESCRIPTION
Good day,

This pull request makes a very small, backwards-compatible enhancement to the `/health` endpoint so that monitoring systems can more easily identify the service that is responding.

#### What this PR changes

In `backend/app.py`:

- The `health()` endpoint response is extended from:

  ```json
  {"status": "ok", "timestamp": "..."}
  ```

  to:

  ```json
  {
    "status": "ok",
    "service": "star-office-ui",
    "timestamp": "..."
  }
  ```

- The HTTP method (`GET`), route (`/health`), and status code (`200`) remain exactly the same.

#### Rationale

- Many monitoring and load-balancing setups like to tag checks with a service identifier, especially when multiple apps are running behind the same gateway or on the same host.
- Adding a simple `service` field makes it trivial for dashboards, alerts, or logs to distinguish “this is Star Office UI” without having to rely on URL patterns or hostnames alone.
- The change is intentionally minimal and does not remove or rename any existing fields, preserving compatibility with current consumers that only read `status` and/or `timestamp`.

#### Compatibility

- Existing clients that parse `/health` as JSON and only rely on `status` (or `timestamp`) will continue to work unchanged.
- New clients can optionally use `service === "star-office-ui"` as an additional guard or label.

Warmly,
Jah-yee
