### PR TITLE
fix: avoid 401 Unauthorized on first page load (fixes #54)

### DIFF
--- a/frontend/electron-standalone.html
+++ b/frontend/electron-standalone.html
@@ -4182,6 +4182,7 @@ function toggleBrokerPanel() {
                 bindAssetDrawerBackgroundDeselect();
                 await ensureGeminiConfigLoaded();
                 if (assetDrawerAuthed) {
+                    await applySavedPositionOverrides();
                     await refreshAssetDrawerList();
                     await renderHomeFavorites(false);
                     bindDrawerFileMeta();
@@ -4212,6 +4213,7 @@ function toggleBrokerPanel() {
                 bindAssetDrawerBackgroundDeselect();
                 await ensureGeminiConfigLoaded();
                 if (assetDrawerAuthed) {
+                    await applySavedPositionOverrides();
                     await refreshAssetDrawerList();
                     await renderHomeFavorites(false);
                     bindDrawerFileMeta();
@@ -4835,7 +4837,15 @@ function toggleBrokerPanel() {
             
             // 启动 Phaser 游戏
             new Phaser.Game(config);
-            setTimeout(() => { applySavedPositionOverrides(); }, 600);
+            setTimeout(async () => {
+                try {
+                    const authRes = await fetch('/assets/auth/status', { cache: 'no-store' });
+                    const authData = await authRes.json();
+                    if (authData && authData.ok && authData.authed) {
+                        await applySavedPositionOverrides();
+                    }
+                } catch (e) {}
+            }, 600);
         }
 
         function preload() {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3300,6 +3300,7 @@ function toggleBrokerPanel() {
                 bindAssetDrawerBackgroundDeselect();
                 await ensureGeminiConfigLoaded();
                 if (assetDrawerAuthed) {
+                    await applySavedPositionOverrides();
                     await refreshAssetDrawerList();
                     await renderHomeFavorites(false);
                     bindDrawerFileMeta();
@@ -3925,7 +3926,15 @@ function toggleBrokerPanel() {
                     console.warn('flowers 规格探测失败，使用默认 65x65', e);
                 }
 
-                applySavedPositionOverrides();
+                // Only fetch /assets/positions and /assets/defaults when user is authed,
+                // to avoid 401 Unauthorized on first load for new visitors (issue #54).
+                try {
+                    const authRes = await fetch('/assets/auth/status', { cache: 'no-store' });
+                    const authData = await authRes.json();
+                    if (authData && authData.ok && authData.authed) {
+                        await applySavedPositionOverrides();
+                    }
+                } catch (e) {}
             }, 600);
         }
 


### PR DESCRIPTION
Good day,

This PR addresses **#54** (browser showing "Unauthorized" when visiting the UI after starting the project per the docs).

**Cause:** A few hundred milliseconds after the main page loads, the frontend calls `/assets/positions` and `/assets/defaults` to apply saved layout. Those endpoints require asset-editor auth and return 401 when the user is not logged in, which can surface as "Unauthorized" in some setups.

**Changes:**
- **Defer asset requests until the user is authed:** In the post-load timeout (600 ms), we first call `/assets/auth/status` (which does not require auth). We only call `applySavedPositionOverrides()` (and thus request `/assets/positions` and `/assets/defaults`) when `authed === true`. New visitors no longer trigger 401 on first load.
- **Apply layout when opening the drawer:** When the user opens the asset drawer and is already authed, we run `applySavedPositionOverrides()` once so that saved positions are still applied after they log in.
- The same logic is applied in both `frontend/index.html` and `frontend/electron-standalone.html`.

No backend or README changes. Behaviour for users who have already authenticated is unchanged.

Warmly,
