### PR TITLE
fix: add startup hints for port and state source (fixes #31)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2053,6 +2053,10 @@ if __name__ == "__main__":
     print("=" * 50)
     print(f"State file: {STATE_FILE}")
     print(f"Listening on: http://0.0.0.0:{backend_port}")
+    if backend_port != 18791:
+        print(f"(Port override: set STAR_BACKEND_PORT to change; current: {raw_port})")
+    else:
+        print("(Set STAR_BACKEND_PORT to use a different port, e.g. 3009)")
     mode = "production" if is_production_mode() else "development"
     print(f"Mode: {mode}")
     if is_production_mode():

--- a/office-agent-push.py
+++ b/office-agent-push.py
@@ -262,6 +262,17 @@ def do_push(local, status_data):
 def main():
     local = load_local_state()
 
+    # Startup hint for state source and URL (helps with port/state issues, e.g. issue #31)
+    if LOCAL_STATE_FILE:
+        print(f"State file: {LOCAL_STATE_FILE}")
+    else:
+        first_existing = next((p for p in DEFAULT_STATE_CANDIDATES if p and os.path.exists(p)), None)
+        if first_existing:
+            print(f"State file (auto): {first_existing}")
+        else:
+            print("State file: auto-discover (set OFFICE_LOCAL_STATE_FILE if state not found)")
+    print(f"Local status URL: {LOCAL_STATUS_URL} (set OFFICE_LOCAL_STATUS_URL if backend uses another port)")
+
     # 先确认配置是否齐全
     if not JOIN_KEY or not AGENT_NAME:
         print("❌ 请先在脚本开头填入 JOIN_KEY 和 AGENT_NAME")


### PR DESCRIPTION
Good day,

This PR addresses **#31** (port 18791 conflict and lobster/cat state not updating).

**Changes:**

1. **Backend (`backend/app.py`)**  
   At startup we now print a short hint about the port:
   - If using the default port 18791: `(Set STAR_BACKEND_PORT to use a different port, e.g. 3009)`
   - If already overridden: `(Port override: set STAR_BACKEND_PORT to change; current: <value>)`  
   So users who hit a port conflict can switch port via `STAR_BACKEND_PORT` without editing the code.

2. **Push script (`office-agent-push.py`)**  
   At startup we now print:
   - Which state file is used (either `OFFICE_LOCAL_STATE_FILE` or the first auto-discovered path, or a message to set the env if none found).
   - The local status URL: `Local status URL: <LOCAL_STATUS_URL> (set OFFICE_LOCAL_STATUS_URL if backend uses another port)`  
   So when the backend runs on another port (e.g. 3009), users see the URL the script uses and can set `OFFICE_LOCAL_STATUS_URL` to match.

No README changes; behaviour is unchanged except for the extra log lines.

Warmly,
