### PR TITLE
docs: add SOUL.md auto-sync hint in set_state.py (fixes #40)

### DIFF
--- a/set_state.py
+++ b/set_state.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""简单的状态更新工具，用于测试 Star Office UI"""
+"""Update Star Office UI state (for testing or agent-driven sync).
+
+For automatic state sync from OpenClaw: add a rule in your agent SOUL.md or AGENTS.md:
+  Before starting a task: run `python3 set_state.py writing "doing XYZ"`.
+  After finishing: run `python3 set_state.py idle "ready"`.
+The office UI reads state from the same state.json this script writes.
+"""
 
 import json
 import os


### PR DESCRIPTION
Good day,

This PR addresses **#40** (how to update state automatically).

**Change:** The module docstring of `set_state.py` is updated to English and now includes a short note on automatic state sync: add a rule in your agent SOUL.md or AGENTS.md to run `python3 set_state.py writing "doing XYZ"` before a task and `python3 set_state.py idle "ready"` after finishing; the office UI reads the same state.json this script writes.

No README or behaviour change; this only makes the “automatic state update” flow discoverable from the script itself (e.g. via editor hover or `python3 set_state.py` usage).

Warmly,
