### PR TITLE
fix: revert OpenClaw URLs back to openclaw.com

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -7,7 +7,7 @@
 **A pixel-art AI office dashboard** — visualize your AI assistant's work status in real time, so you can see at a glance who's doing what, what they did yesterday, and whether they're online.
 
 Supports multi-agent collaboration, trilingual UI (CN/EN/JP), AI-powered room design, and desktop pet mode.
-Best experienced with [OpenClaw](https://github.com/openclaw/openclaw), but also works standalone as a status dashboard.
+Best experienced with [OpenClaw](https://openclaw.com), but also works standalone as a status dashboard.
 
 > This project was co-created by **[Ring Hyacinth](https://x.com/ring_hyacinth)** and **[Simon Lee](https://x.com/simonxxoo)**, and is continuously maintained and improved together with community contributors ([@Zhaohan-Wang](https://github.com/Zhaohan-Wang), [@Jah-yee](https://github.com/Jah-yee), [@liaoandi](https://github.com/liaoandi)).
 > Issues and PRs are welcome — thank you to everyone who contributes.
@@ -18,7 +18,7 @@ Best experienced with [OpenClaw](https://github.com/openclaw/openclaw), but also
 
 ### Option 1: Let your lobster deploy it (recommended for OpenClaw users)
 
-If you're using [OpenClaw](https://github.com/openclaw/openclaw), just send this to your lobster:
+If you're using [OpenClaw](https://openclaw.com), just send this to your lobster:
 
 ```text
 Please follow this SKILL.md to deploy Star Office UI for me:
@@ -142,7 +142,7 @@ If all checks report `OK`, your deployment is good to go.
 
 ## 🦞 OpenClaw Deep Integration
 
-> The following section is for [OpenClaw](https://github.com/openclaw/openclaw) users. If you don't use OpenClaw, feel free to skip this.
+> The following section is for [OpenClaw](https://openclaw.com) users. If you don't use OpenClaw, feel free to skip this.
 
 ### Automatic Status Sync
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 **ピクセルアート風 AI オフィスダッシュボード** —— AI アシスタントの作業状態をリアルタイムで可視化し、「誰が何をしているか」「昨日何をしたか」「今オンラインか」を直感的に把握できます。
 
 マルチ Agent 協調、中英日 3 言語、AI 画像生成による模様替え、デスクトップペットモードに対応。
-[OpenClaw](https://github.com/openclaw/openclaw) との統合で最高の体験が得られますが、単体でもステータスダッシュボードとして利用可能です。
+[OpenClaw](https://openclaw.com) との統合で最高の体験が得られますが、単体でもステータスダッシュボードとして利用可能です。
 
 > 本プロジェクトは **[Ring Hyacinth](https://x.com/ring_hyacinth)** と **[Simon Lee](https://x.com/simonxxoo)** の共同制作（co-created project）であり、コミュニティの開発者（[@Zhaohan-Wang](https://github.com/Zhaohan-Wang)、[@Jah-yee](https://github.com/Jah-yee)、[@liaoandi](https://github.com/liaoandi)）とともに継続的にメンテナンス・改善を行っています。
 > Issue や PR を歓迎します。貢献してくださるすべての方に感謝いたします。
@@ -18,7 +18,7 @@
 
 ### 方法 1：ロブスターにデプロイしてもらう（OpenClaw ユーザー向け）
 
-[OpenClaw](https://github.com/openclaw/openclaw) をご利用中なら、以下のメッセージをロブスターに送るだけ：
+[OpenClaw](https://openclaw.com) をご利用中なら、以下のメッセージをロブスターに送るだけ：
 
 ```text
 この SKILL.md に従って Star Office UI をデプロイしてください：
@@ -142,7 +142,7 @@ python3 scripts/smoke_test.py --base-url http://127.0.0.1:19000
 
 ## 🦞 OpenClaw 連携
 
-> 以下は [OpenClaw](https://github.com/openclaw/openclaw) ユーザー向けの内容です。OpenClaw を使用していない場合はスキップしてください。
+> 以下は [OpenClaw](https://openclaw.com) ユーザー向けの内容です。OpenClaw を使用していない場合はスキップしてください。
 
 ### ステータス自動同期
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **一个像素风格的 AI 办公室看板** —— 把 AI 助手的工作状态实时可视化，让你直观看到"谁在做什么、昨天做了什么、现在是否在线"。
 
 支持多 Agent 协作、中英日三语、AI 生图装修、桌面宠物模式。
-与 [OpenClaw](https://github.com/openclaw/openclaw) 深度集成时体验最佳，也可以独立部署作为状态看板使用。
+与 [OpenClaw](https://openclaw.com) 深度集成时体验最佳，也可以独立部署作为状态看板使用。
 
 > 本项目由 **[Ring Hyacinth](https://x.com/ring_hyacinth)** 与 **[Simon Lee](https://x.com/simonxxoo)** 共同创建（co-created project），并与社区开发者（[@Zhaohan-Wang](https://github.com/Zhaohan-Wang)、[@Jah-yee](https://github.com/Jah-yee)、[@liaoandi](https://github.com/liaoandi)）一起持续维护和共建。
 > 欢迎提交 Issue 和 PR，也感谢每一位贡献者的支持。
@@ -18,7 +18,7 @@
 
 ### 方式一：让龙虾帮你部署（推荐给 OpenClaw 用户）
 
-如果你正在使用 [OpenClaw](https://github.com/openclaw/openclaw)，直接把下面这句话发给你的龙虾：
+如果你正在使用 [OpenClaw](https://openclaw.com)，直接把下面这句话发给你的龙虾：
 
 ```text
 请按照这个 SKILL.md 帮我完成 Star Office UI 的部署：
@@ -143,7 +143,7 @@ python3 scripts/smoke_test.py --base-url http://127.0.0.1:19000
 
 ## 🦞 OpenClaw 深度集成
 
-> 以下内容面向 [OpenClaw](https://github.com/openclaw/openclaw) 用户。如果你不使用 OpenClaw，可以跳过这一节。
+> 以下内容面向 [OpenClaw](https://openclaw.com) 用户。如果你不使用 OpenClaw，可以跳过这一节。
 
 ### 状态自动同步
 


### PR DESCRIPTION
Reverts commit 61a5d5f which changed OpenClaw links from https://openclaw.com to https://github.com/openclaw/openclaw in all three README files. The correct URL for OpenClaw is the product website https://openclaw.com, not the GitHub repository.

Made with [Cursor](https://cursor.com)