### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Star Office UI
 
+[![Listed on TakoAPI](https://img.shields.io/badge/Listed%20on-TakoAPI-7c3aed)](https://takoapi.com/agents/ringhyacinth-star-office-ui)
+
 🌐 Language: **中文** | [English](./README.en.md) | [日本語](./README.ja.md)
 
 ![Star Office UI 封面](docs/screenshots/readme-cover-2.jpg)


### PR DESCRIPTION
Hi! 👋 **Star-Office-UI** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/ringhyacinth-star-office-ui

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building Star-Office-UI! 🙏